### PR TITLE
Enabled the suid chrome-sandbox

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,7 +57,7 @@ parts:
     override-pull: |
       set -eu
       craftctl default
-      chmod 0755 ./opt/brave.com/brave/chrome-sandbox
+      chmod 4555 ./opt/brave.com/brave/chrome-sandbox
       rm -rf etc/cron.daily/ usr/bin/brave-browser usr/bin/brave-browser-stable
       sed -i 's|Icon=brave-browser|Icon=/opt/brave.com/brave/product_logo_128\.png|g' usr/share/applications/brave-browser.desktop
     prime:
@@ -89,4 +89,3 @@ parts:
       - -usr/share/upstart
       - -usr/share/zsh
       - -var
-      - -opt/brave.com/brave/chrome-sandbox


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/18768

With this patch, on my system with CONFIG_USER_NS_UNPRIVILEGED disabled, I'm able to run without `--no-sandbox` and everything appears to be working, based on a quick look.

The only concern I currently have is about the first error printed

```console
% snap run brave                                                                                                                                                                         
update.go:85: cannot change mount namespace according to change mount (/run/user/1000/doc/by-app/snap.brave /run/user/1000/doc none bind,rw,x-snapd.ignore-missing 0 0): cannot inspect "/run/user/1000/doc": lstat /run/user/1000/doc: permiss
ion denied                                                                                                                                                                                                                                     
[2770444:2770444:0510/180412.558895:ERROR:chrome_browser_cloud_management_controller.cc(162)] Cloud management controller initialization aborted as CBCM is not enabled.                                                                       
WARNING: Kernel has no file descriptor comparison support: Operation not permitted                                                                                                                                                             
[2770444:2770461:0510/180415.522382:ERROR:udev_watcher.cc(98)] Failed to begin udev enumeration.
%
```