### PR TITLE
Removed cups-control

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,7 +31,6 @@ apps:
       - camera
       - content
       - cups
-      - cups-control
       - home
       - joystick
       - mount-observe


### PR DESCRIPTION
Per https://snapcraft.io/docs/cups-interface:
> If you are maintaining an application snap currently using cups-control for printing, switch to the cups interface

> However, the cups interface and the cups-control interface should not be used as plugs in the same snap.